### PR TITLE
Updated API wrapper as per the changes in API responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,35 @@
+# project specific
+db.sqlite3
+*.sqlite3
+favicons.zip
+links.txt
+sandbox/
+static/
+upload/
+models_*.pdf
+models_*.png
+dump.rdb
+
+
+# dotenv
+.env
+env
+
+# production
+production.py
+credentials/
+credentials.py
+
+# User list
+auth.User.json
+
+# Data
+data/
+export.csv
+*.csv
+*.csv.gz
+*.docx
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
@@ -6,25 +38,32 @@ __pycache__/
 # C extensions
 *.so
 
+# Lock files
+~*.xlsx
+*.swp
+
 # Distribution / packaging
+src/
 .Python
+.DS_Store
 build/
-develop-eggs/
 dist/
 downloads/
-eggs/
 .eggs/
+*.egg
+*.egg-info/
+eggs/
+develop-eggs/
 lib/
 lib64/
 parts/
 sdist/
 var/
 wheels/
-share/python-wheels/
-*.egg-info/
 .installed.cfg
-*.egg
-MANIFEST
+
+#
+source/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template
@@ -39,17 +78,13 @@ pip-delete-this-directory.txt
 # Unit test / coverage reports
 htmlcov/
 .tox/
-.nox/
 .coverage
 .coverage.*
 .cache
 nosetests.xml
 coverage.xml
-*.cover
-*.py,cover
+*,cover
 .hypothesis/
-.pytest_cache/
-cover/
 
 # Translations
 *.mo
@@ -58,8 +93,6 @@ cover/
 # Django stuff:
 *.log
 local_settings.py
-db.sqlite3
-db.sqlite3-journal
 
 # Flask stuff:
 instance/
@@ -72,61 +105,26 @@ instance/
 docs/_build/
 
 # PyBuilder
-.pybuilder/
 target/
 
 # Jupyter Notebook
 .ipynb_checkpoints
 
-# IPython
-profile_default/
-ipython_config.py
-
 # pyenv
-#   For a library or package, you might want to ignore these files since the code is
-#   intended to run in multiple environments; otherwise, check them in:
-# .python-version
+.python-version
 
-# pipenv
-#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
-#   However, in case of collaboration, if having platform-specific dependencies or dependencies
-#   having no cross-platform support, pipenv may install dependencies that don't work, or not
-#   install all needed dependencies.
-#Pipfile.lock
-
-# poetry
-#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
-#   This is especially recommended for binary packages to ensure reproducibility, and is more
-#   commonly ignored for libraries.
-#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
-#poetry.lock
-
-# pdm
-#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
-#pdm.lock
-#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
-#   in version control.
-#   https://pdm.fming.dev/#use-with-ide
-.pdm.toml
-
-# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
-__pypackages__/
-
-# Celery stuff
+# celery beat schedule file
 celerybeat-schedule
 celerybeat.pid
 
 # SageMath parsed files
 *.sage.py
 
-# Environments
-.env
+# virtualenv
 .venv
 env/
 venv/
 ENV/
-env.bak/
-venv.bak/
 
 # Spyder project settings
 .spyderproject
@@ -138,23 +136,18 @@ venv.bak/
 # mkdocs documentation
 /site
 
-# mypy
-.mypy_cache/
-.dmypy.json
-dmypy.json
-
-# Pyre type checker
-.pyre/
-
-# pytype static type analyzer
-.pytype/
-
-# Cython debug symbols
-cython_debug/
-
 # PyCharm
-#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
-#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
-#  and can be added to the global gitignore or merged into this file.  For a more nuclear
-#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
+
+# Visual Studio Code
+.vscode/
+
+# Media folder
+media/
+uploads/
+
+#vue related
+node_modules/
+
+# pylint config
+.pylintrc

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 – slug<br>
 – iso<br>
 – name<br>
+– user<br>
 – category<br>
 – status<br>
 – refdate: datetime<br>
@@ -14,6 +15,8 @@
 – nodes: {node_slug: [Node](#node), ...}<br>
 – scenarios: {scenario_slug: [Scenario](#scenario), ...}<br>
 – node_scenarios: {node_scenario_slug: [NodeScenario](#nodescenario), ...}
+
+– `set_user(email)`
 
 ## Node
 
@@ -36,6 +39,7 @@
 – slug<br>
 – node: [Node](#node)<br>
 – scenario: [Scenario](#scenario)<br>
+– params: [ScenarioParams](#scenarioparams)<br>
 – status<br>
 – results (TBD)
 

--- a/bos_client/batteryos.py
+++ b/bos_client/batteryos.py
@@ -274,8 +274,8 @@ class ScenarioParams(BatteryOS):
         endpoint = f"calc/{self.scenario.calc.slug}/scenarios/{self.scenario.slug}/params/"
         content = self.request(endpoint)
 
-        for key in content:
-            setattr(self, key, content.get(key))
+        for key in content["params"]:
+            setattr(self, key, content["params"].get(key))
 
 
 class NodeScenario(BatteryOS):

--- a/bos_client/batteryos.py
+++ b/bos_client/batteryos.py
@@ -64,7 +64,7 @@ class BatteryosApiPathNotDefinedError(Exception):
 
 class BatteryOS:
     @staticmethod
-    def get_content(endpoint):
+    def request(endpoint, method="get", data=None):
         token = os.getenv("BATTERYOS_TOKEN", None)
         if token is None:
             raise BatteryosApiTokenNotFoundError
@@ -75,11 +75,19 @@ class BatteryOS:
         if apipath is None:
             raise BatteryosApiPathNotDefinedError
 
-        response = requests.get(
-            apipath + endpoint,
-            headers=headers,
-            timeout=30,
-        )
+        request_params = {
+            "url": apipath + endpoint,
+            "headers": headers,
+            "timeout": 30,
+        }
+        if data:
+            request_params["data"] = data
+
+        req_method = getattr(requests, method.lower(), None)
+        if req_method is None:
+            return {}
+
+        response = req_method(**request_params)
         if response.status_code != 200:
             print(f"{apipath + endpoint}: {response.status_code}")
             return {}
@@ -108,18 +116,12 @@ class Calc(BatteryOS):
         self.slug = None
         self.iso = None
         self.name = None
-
-        # key in params, not in response for calc
-        # self.category = None
-
+        self.user = None
+        self.category = None
         self.status = None
-
-        # will be added
         self.refdate = None
-
         self.start = None
         self.end = None
-
         self.data = {}
         self.nodes = {}
         self.scenarios = {}
@@ -130,7 +132,7 @@ class Calc(BatteryOS):
 
     def load(self):
         endpoint = f"calc/{self.slug}/"
-        content = self.get_content(endpoint)
+        content = self.request(endpoint)
         self.iso = content.get("iso")
         self.name = content.get("name")
         self.status = content.get("status")
@@ -139,20 +141,18 @@ class Calc(BatteryOS):
         self.end = todate(content.get("enddate", None))
         self.refdate = todate(content.get("refdate", None))
 
+        # Get user
+        endpoint = f"calc/{self.slug}/user/"
+        content = self.request(endpoint)
+        self.user = content.get("user")
+
         endpoint = f"calc/{self.slug}/nodescenarios/"
-        content = self.get_content(endpoint)
+        content = self.request(endpoint)
 
         for ns_slug in content:
-            # data_slug = scenario_content.get("data_slug")
-            # data_list = [x for x in self.data if x.slug == data_slug]
-            # if not data_list:
-            #     data = Data(slug=data_slug)
-            #     data.load()
-            #     self.data.append(data)
+            ns_content = self.request(endpoint + ns_slug + "/")
 
-            resp = self.get_content(endpoint + ns_slug + "/")
-
-            slug = resp.get("node_slug")
+            slug = ns_content.get("node_slug")
             if slug in self.nodes:
                 node = self.nodes[slug]
             else:
@@ -160,7 +160,7 @@ class Calc(BatteryOS):
                 node.load()
                 self.nodes[slug] = node
 
-            slug = resp.get("scenario_slug", None)
+            slug = ns_content.get("scenario_slug", None)
             if slug in self.scenarios:
                 scenario = self.scenarios[slug]
             else:
@@ -168,20 +168,27 @@ class Calc(BatteryOS):
                 scenario.load()
                 self.scenarios[slug] = scenario
 
-            slug = resp.get("nodescenario_slug")
+            slug = ns_content.get("nodescenario_slug")
             if slug not in self.node_scenarios:
                 node_scenario = NodeScenario(calc=self, slug=slug)
                 node_scenario.node = node
                 node_scenario.scenario = scenario
-                self.node_scenarios[slug] = node_scenario
                 node_scenario.load()
+                self.node_scenarios[slug] = node_scenario
+
+    def set_user(self, user):
+        endpoint = f"calc/{self.slug}/user/"
+        data = {"user": user}
+        content = self.request(endpoint, method="put", data=data)
+        self.user = content.get("user")
+        return self.user
 
 
 class Node(BatteryOS):
     """
     GET
     - calc/<calc_slug>/nodes/
-    ? calc/<calc_slug>/nodes/<node_slug>/
+    - calc/<calc_slug>/nodes/<node_slug>/
     """
 
     def __init__(self, calc=None, slug=None):
@@ -190,12 +197,10 @@ class Node(BatteryOS):
 
         self.iso = None
         self.name = None
-        # self.category = None
 
     def load(self):
         endpoint = f"calc/{self.calc.slug}/nodes/{self.slug}/"
-        content = self.get_content(endpoint)
-        # content = {}
+        content = self.request(endpoint)
 
         self.iso = self.calc.iso
         self.name = content.get("name")
@@ -206,31 +211,29 @@ class Scenario(BatteryOS):
     GET
     - calc/<calc_slug>/scenarios/
     - calc/<calc_slug>/scenarios/<scenario_slug>/
+    - calc/<calc_slug>/scenarios/<scenario_slug>/params/
     """
 
     def __init__(self, calc=None, slug=None):
         self.calc = calc
         self.slug = slug
-
         self.name = None
-
-        # params are no more present in response, hence removing it
-        # self.params = None
+        self.params = None
 
     def load(self):
         endpoint = f"calc/{self.calc.slug}/scenarios/{self.slug}/"
-        content = self.get_content(endpoint)
+        content = self.request(endpoint)
 
         self.name = content.get("name")
-        # self.params = ScenarioParams()
-        # self.params.load(content.get("params"))
+        self.params = ScenarioParams(scenario=self)
+        self.params.load()
 
 
-class NodeScenarioParams(BatteryOS):
+class ScenarioParams(BatteryOS):
     # pylint: disable=too-many-instance-attributes
 
-    def __init__(self, node_scenario=None):
-        self.node_scenario = node_scenario
+    def __init__(self, scenario=None):
+        self.scenario = scenario
         self.capacity = None
         self.duration = None
         self.min_cycles = None
@@ -267,18 +270,9 @@ class NodeScenarioParams(BatteryOS):
         self.operational_months = None
         self.model = None
 
-    def load(self, *args):
-        if not args:
-            return
-
-        content = args[0]
-
-        # if isinstance(content, list):
-        #     for param in content:
-        #         setattr(self, param["name"], param["value"])
-        # elif isinstance(content, dict):
-        #     for key in content:
-        #         setattr(self, key, content.get(key))
+    def load(self):
+        endpoint = f"calc/{self.scenario.calc.slug}/scenarios/{self.scenario.slug}/params/"
+        content = self.request(endpoint)
 
         for key in content:
             setattr(self, key, content.get(key))
@@ -288,9 +282,8 @@ class NodeScenario(BatteryOS):
     """
     GET
     - calc/<calc_slug>/nodescenarios/
-    ? calc/<calc_slug>/nodescenarios/<nodescenario_slug>/
+    - calc/<calc_slug>/nodescenarios/<nodescenario_slug>/
     - calc/<calc_slug>/nodescenarios/<nodescenario_slug>/result/
-    - calc/<calc_slug>/nodescenarios/<nodescenario_slug>/params/
     - calc/<calc_slug>/nodescenarios/<nodescenario_slug>/status/
     """
 
@@ -300,36 +293,16 @@ class NodeScenario(BatteryOS):
         self.node = None
         self.scenario = None
         self.status = None
-        self.params = None
 
     def load(self):
         endpoint = f"calc/{self.calc.slug}/nodescenarios/"
-        # node and scenario are already set in Calc, hence removing the same from here
-        # content = self.get_content(endpoint)
 
-        # self.node = Node(calc=self.calc)
-        # self.node.slug = content[0].get("node_slug")
-        # self.node.name = content[0].get("node_name")
-        # self.slug = content[0].get("node_scenario_slug")
-        # self.scenario = Scenario(calc=self.calc)
-        # self.scenario.slug = content[0].get("scenario_slug")
-        # self.scenario.name = content[0].get("scenario_name")
-
-        # TODO
-        # content = self.get_content(endpoint + self.slug + "/result/")
-        # self.detail = content.get("detail")
-
-        content = self.get_content(endpoint + self.slug + "/params/")
-        params = NodeScenarioParams(node_scenario=self)
-        self.params = params
-        params.load(content.get("params"))
-
-        content = self.get_content(endpoint + self.slug + "/status/")
+        content = self.request(endpoint + self.slug + "/status/")
         self.status = content.get("status")
 
-    # @property
-    # def params(self):
-    #     return self.scenario.params
+    @property
+    def params(self):
+        return self.scenario.params
 
 
 class Data(BatteryOS):
@@ -351,7 +324,7 @@ class Data(BatteryOS):
 
     def load(self):
         # endpoint = f"data/{self.slug}/"
-        # content = self.get_content(endpoint)
+        # content = self.request(endpoint)
         content = {}
 
         self.iso = content.get("iso")


### PR DESCRIPTION
In Calc : 
- The property "category" was present in params, since we have removed params from response hence removed "category" as well.
- The property "refdate" does not get set currently, changes would be required for it in the API
- Initially we were getting a list of dictionaries after calling "calc/<slug:slug>/nodescenarios. Now we get a list of nodescenario_slugs. Hence modified the later part accordingly

In Node : 
- Made a call to "calc/<slug:calc_slug>/nodes/<slug:node_slug>/" to get node_name

In Scenario : 
- Made a call to "calc/<slug:calc_slug>/scenarios/<slug:scenario_slug>/" to get scenario_name
- "params" are no more present in response hence removed it

In NodeScenario:
- "node" and "scenario" are already set in Calc, hence removed the same from NodeScenario
- Updated the property "params" to store object of NodeScenarioParams

In NodeScenarioParams : 
- "params" have only one format {param_name : param_value}. So updated the code accordingly

